### PR TITLE
fix : allow users to open a specific execution

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -1802,7 +1802,6 @@ export default {
           });
         }
       }
-      console.log(updatedItems);
       await this.$store.commit("setSessionItems", [...updatedItems]);
       await this.$store.commit("setSessionNodes", [...updatedNodes]);
       await this.$store.commit("setSessionConnections", [

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -103,11 +103,7 @@ const routes = [
     path: "/main",
     name: "main",
     component: MainView,
-    children: [
-      {
-        path: "workspace",
-      },
-    ],
+    children: [{ path: "workspace" }, { path: "workspace/:execID" }],
   },
   {
     path: "/settings",

--- a/src/services/storage-options/restApiService.js
+++ b/src/services/storage-options/restApiService.js
@@ -128,6 +128,13 @@ export default class RestApiService extends StorageInterface {
     };
   }
 
+  async getStateMethod(executionId) {
+    const { data } = await axios.get(
+      `http://localhost:5000/v1/pinata/executions/${executionId}`
+    );
+    return data;
+  }
+
   async getMetaData() {}
 
   async updateCredentials(credentials) {

--- a/src/services/storage-options/restApiService.js
+++ b/src/services/storage-options/restApiService.js
@@ -4,9 +4,11 @@ import StorageInterface from "../storageInterface";
 import store from "@/store";
 
 export default class RestApiService extends StorageInterface {
-  async getState() {
-    const response = await axios.get(`http://localhost:3000/state`);
-    return response.data;
+  async getState(executionId) {
+    const { data } = await axios.get(
+      `http://localhost:5000/v1/pinata/executions/${executionId}`
+    );
+    return data;
   }
 
   async updateState(state) {
@@ -126,13 +128,6 @@ export default class RestApiService extends StorageInterface {
         },
       ],
     };
-  }
-
-  async getStateMethod(executionId) {
-    const { data } = await axios.get(
-      `http://localhost:5000/v1/pinata/executions/${executionId}`
-    );
-    return data;
   }
 
   async getMetaData() {}

--- a/src/services/storageInterface.js
+++ b/src/services/storageInterface.js
@@ -1,5 +1,6 @@
 export default class StorageInterface {
-  async getState() {
+  // eslint-disable-next-line
+  async getState(executionId) {
     throw new Error("Method 'getState()' must be implemented.");
   }
 
@@ -14,11 +15,6 @@ export default class StorageInterface {
 
   async getCredentials() {
     throw new Error("Method 'getCredentials()' must be implemented.");
-  }
-
-  // eslint-disable-next-line
-  async getStateMethod(executionId) {
-    throw new Error("Method 'getStateMethod()' must be implemented.");
   }
 
   // eslint-disable-next-line

--- a/src/services/storageInterface.js
+++ b/src/services/storageInterface.js
@@ -17,6 +17,11 @@ export default class StorageInterface {
   }
 
   // eslint-disable-next-line
+  async getStateMethod(executionId) {
+    throw new Error("Method 'getStateMethod()' must be implemented.");
+  }
+
+  // eslint-disable-next-line
   async updateCredentials(credentials) {
     throw new Error("Method 'updateCredentials()' must be implemented.");
   }

--- a/src/services/storageService.js
+++ b/src/services/storageService.js
@@ -8,8 +8,8 @@ export default class StorageService {
       : new RestApiService();
   }
 
-  async getState() {
-    return await this.storage.getState();
+  async getState(executionId) {
+    return await this.storage.getState(executionId);
   }
 
   async updateState(state) {
@@ -26,10 +26,6 @@ export default class StorageService {
 
   async getCredentials() {
     return await this.storage.getCredentials();
-  }
-
-  async getStateMethod(executionId) {
-    return await this.storage.getStateMethod(executionId);
   }
 
   async getMetaData() {

--- a/src/services/storageService.js
+++ b/src/services/storageService.js
@@ -28,6 +28,10 @@ export default class StorageService {
     return await this.storage.getCredentials();
   }
 
+  async getStateMethod(executionId) {
+    return await this.storage.getStateMethod(executionId);
+  }
+
   async getMetaData() {
     return await this.storage.getMetaData();
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -173,12 +173,14 @@ const store = new Vuex.Store({
       }
       this._vm.$storageService.updateItem(payload);
     },
+
     deleteSessionItems(state, ids) {
       state.session.items = ids.reduce((acc, currentId) => {
         return acc.filter((item) => item.stepID !== currentId);
       }, state.session.items);
       this._vm.$storageService.deleteItems(ids);
     },
+
     setSessionNotes(state, payload) {
       state.session.notes.content = payload.content;
       state.session.notes.text = payload.text;
@@ -186,6 +188,7 @@ const store = new Vuex.Store({
         this._vm.$storageService.updateState(state);
       }
     },
+
     updateSession(state, payload) {
       let isStatusChanged = false;
       if (state.session.status !== payload.status) {
@@ -198,6 +201,15 @@ const store = new Vuex.Store({
       if (state.case.duration !== payload.duration) {
         state.case.duration = payload.duration;
       }
+      if (state.session.ended !== payload.ended && payload.ended) {
+        state.session.ended = payload.ended;
+      }
+      if (state.session.quickTest !== payload.quickTest && payload.quickTest) {
+        state.session.quickTest = payload.quickTest;
+      }
+      if (state.session.sessionID !== payload.sessionID && payload.sessionID) {
+        state.session.sessionID = payload.sessionID;
+      }
 
       if (
         Vue.prototype.$isElectron ||
@@ -209,6 +221,7 @@ const store = new Vuex.Store({
         this._vm.$storageService.updateState(state);
       }
     },
+
     clearState(state) {
       state.case.caseID = null;
       state.case.title = "";
@@ -287,6 +300,7 @@ const store = new Vuex.Store({
       state.session.ended = "";
       this._vm.$storageService.updateState(state);
     },
+
     restoreState(state, payload) {
       state.case = {
         ...state.case,
@@ -319,6 +333,7 @@ const store = new Vuex.Store({
 
       this._vm.$storageService.updateState(state);
     },
+
     togglePreSessionTask(state, { taskId, checked }) {
       const taskIndex = state.session.preSessionTasks.findIndex(
         (task) => task.id === taskId
@@ -327,6 +342,7 @@ const store = new Vuex.Store({
         state.session.preSessionTasks[taskIndex].checked = checked;
       }
     },
+
     togglePostSessionTask(state, { taskId, checked }) {
       const taskIndex = state.session.postSessionTasks.findIndex(
         (task) => task.id === taskId

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -173,6 +173,7 @@ export default {
       this.$electronService.onDataChange(this.fetchItems);
       this.$electronService.onMetaChange(this.fetchItems);
     }
+    this.getCurrentExecution();
   },
   computed: {
     ...mapGetters({
@@ -231,6 +232,22 @@ export default {
       if (this.$isElectron) {
         const sessionItems = await this.$storageService.getItems();
         this.$store.commit("setSessionItemsFromExternalWindow", sessionItems);
+      }
+    },
+    async getCurrentExecution() {
+      let currentPath = this.$route.path;
+      const executionId = currentPath.split("/").pop();
+
+      if (executionId !== "" && executionId !== "workspace") {
+        const currentExecution = await this.$storageService.getStateMethod(
+          executionId
+        );
+        const data = currentExecution.custom_fields;
+        this.$store.commit("updateSession", data);
+        this.$store.commit("setSessionItems", data.items);
+        this.$store.commit("setSessionNodes", data.nodes);
+        this.$store.commit("setSessionConnections", data.connections);
+        await this.$router.push({ path: "/main/workspace" });
       }
     },
     addItem(newItem) {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -239,7 +239,7 @@ export default {
       const executionId = currentPath.split("/").pop();
 
       if (executionId !== "" && executionId !== "workspace") {
-        const currentExecution = await this.$storageService.getStateMethod(
+        const currentExecution = await this.$storageService.getState(
           executionId
         );
         const data = currentExecution.custom_fields;


### PR DESCRIPTION
Allow users to open a specific execution by specifying an execution **UID** in the querystring of the URL for the workspace.
Currently, It pulls the execution data from the backend at **pinata/executions/:executionID** and then clear the querystring so that it is empty after opening the correct test.

This is the **getStatemethod** in src/services/storage-options/restApiService.js.